### PR TITLE
Suppress conversational preambles in output

### DIFF
--- a/internal/config/assets/conventional.md
+++ b/internal/config/assets/conventional.md
@@ -12,8 +12,3 @@ Rules:
   - Describe the breaking change clearly in the footer using "BREAKING CHANGE:"
 - If useful, add a body explaining *why* the change was made, not just what changed
 - Wrap body lines at approximately 72 characters
-- Do not mention the diff, filenames, or line numbers explicitly
-- Do not wrap the message in backticks or code fences
-- Output only the commit message, with no extra commentary
-
-Write the commit message based on the following git diff:

--- a/internal/config/assets/default.md
+++ b/internal/config/assets/default.md
@@ -20,8 +20,3 @@ Rules:
   - Use full sentences and paragraphs as needed
 
 - Do not include metadata such as timestamps or author names
-- Do not mention the diff, file names, or line numbers explicitly
-- Do not wrap the message in backticks or code fences
-- Output only the commit message, with no additional explanations
-
-Write the commit message based on the following git diff:

--- a/internal/config/assets/gitmoji.md
+++ b/internal/config/assets/gitmoji.md
@@ -26,8 +26,3 @@ Rules:
 - Use only one emoji per commit
 - Do not include Conventional Commits types (feat, fix, etc.)
 - Do not mix multiple conventions in a single commit
-- Do not mention the diff, file names, or line numbers explicitly
-- Do not wrap the message in backticks or code fences
-- Output only the commit message, with no explanations or metadata
-
-Write the commit message based on the following git diff:

--- a/internal/config/assets/karma.md
+++ b/internal/config/assets/karma.md
@@ -34,9 +34,3 @@ Rules:
 - If the change introduces a breaking change:
   - Use BREAKING CHANGE in the footer
   - The subject must describe the change, not the migration steps
-
-- Do not reference the diff, file names, or line numbers directly
-- Do not wrap the message in backticks or code fences
-- Output only the commit message, without any explanations or metadata
-
-Write the commit message based on the following git diff:

--- a/internal/prompt/prompt.tmpl
+++ b/internal/prompt/prompt.tmpl
@@ -1,0 +1,19 @@
+=== INSTRUCTIONS ===
+{{.SystemPrompt}}
+
+OUTPUT RULES:
+- Output only a Git commit message
+- Begin with the commit subject line
+- Exclude explanations, preambles, and meta commentary
+- DO NOT reference diffs, file names, or line numbers
+- DO NOT use code fences or backticks
+
+{{if .Context}}
+=== CONTEXT ===
+{{.Context}}
+{{end}}
+
+=== GIT DIFF ===
+{{.Diff}}
+
+=== OUTPUT ===

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,11 +1,63 @@
 package prompt
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBuild(t *testing.T) {
 	got := Build("sys", "ctx", "diff")
-	expected := "System Prompt:\nsys\n\nContext:\nctx\n\nGit Diff:\ndiff"
-	if got != expected {
-		t.Fatalf("Build = %q", got)
+
+	// Check that output contains expected sections
+	if !strings.Contains(got, "=== INSTRUCTIONS ===") {
+		t.Fatal("Build output should contain INSTRUCTIONS section")
+	}
+	if !strings.Contains(got, "sys") {
+		t.Fatal("Build output should contain system prompt")
+	}
+	if !strings.Contains(got, "OUTPUT RULES:") {
+		t.Fatal("Build output should contain OUTPUT RULES section")
+	}
+	if !strings.Contains(got, "=== CONTEXT ===") {
+		t.Fatal("Build output should contain CONTEXT section when context provided")
+	}
+	if !strings.Contains(got, "ctx") {
+		t.Fatal("Build output should contain context content")
+	}
+	if !strings.Contains(got, "=== GIT DIFF ===") {
+		t.Fatal("Build output should contain GIT DIFF section")
+	}
+	if !strings.Contains(got, "diff") {
+		t.Fatal("Build output should contain diff content")
+	}
+	if !strings.Contains(got, "=== OUTPUT ===") {
+		t.Fatal("Build output should contain OUTPUT section")
+	}
+}
+
+func TestBuildWithoutContext(t *testing.T) {
+	got := Build("sys", "", "diff")
+
+	// Check that output omits CONTEXT section when empty
+	if strings.Contains(got, "=== CONTEXT ===") {
+		t.Fatal("Build output should not contain CONTEXT section when context is empty")
+	}
+	if !strings.Contains(got, "=== INSTRUCTIONS ===") {
+		t.Fatal("Build output should contain INSTRUCTIONS section")
+	}
+	if !strings.Contains(got, "=== GIT DIFF ===") {
+		t.Fatal("Build output should contain GIT DIFF section")
+	}
+}
+
+func TestBuildOutputRules(t *testing.T) {
+	got := Build("sys", "ctx", "diff")
+
+	// Verify output rules are included
+	if !strings.Contains(got, "Exclude explanations, preambles") {
+		t.Fatal("Build output should contain preamble suppression rule")
+	}
+	if !strings.Contains(got, "Begin with the commit subject line") {
+		t.Fatal("Build output should contain direct start instruction")
 	}
 }


### PR DESCRIPTION
This PR addresses the issue where the model prepends conversational explanations instead of outputting only the intended structured result (e.g. a Git commit message), even when explicitly instructed otherwise.
Fixes #1.

The root cause was fragmented and inconsistent prompt construction. Output-suppression rules were duplicated across multiple convention assets and combined via manual string concatenation, which reduced their effectiveness and made behavior sensitive to language and environment.

This change migrates prompt construction to a single template-based system. All output rules are centralized and applied consistently at the system level, with a clearly defined structure that separates instructions, context, diff, and expected output. This makes it harder for the model to ignore or reinterpret the constraints.

### Key changes include:

* Replacing ad-hoc string building with a Go text/template–based prompt.
* Centralizing output-only rules in the template and removing redundant rules from convention assets.
* Introducing a PromptData struct for explicit, maintainable data passing.
* Adding a safe fallback path if template rendering fails.
* Expanding tests to validate prompt structure and the presence of critical output rules.

With this structure, the model is consistently guided to start directly with the commit subject and suppress conversational preambles, regardless of terminal language or locale.

