### PR TITLE
Add --version flag and embed build-time version metadata

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,8 @@ builds:
   - id: git-ai-commit
     main: ./cmd/git-ai-commit
     binary: git-ai-commit
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/git-ai-commit/main.go
+++ b/cmd/git-ai-commit/main.go
@@ -9,6 +9,11 @@ import (
 	"git-ai-commit/internal/app"
 )
 
+var (
+	version = "dev"
+	commit  = "none"
+)
+
 type options struct {
 	context      string
 	contextFile  string
@@ -27,6 +32,10 @@ func main() {
 	if err != nil {
 		if errors.Is(err, errHelp) {
 			printUsage(os.Stdout)
+			return
+		}
+		if errors.Is(err, errVersion) {
+			printVersion()
 			return
 		}
 		fmt.Fprintln(os.Stderr, err)
@@ -51,6 +60,7 @@ func main() {
 }
 
 var errHelp = errors.New("help requested")
+var errVersion = errors.New("version requested")
 
 func parseArgs(args []string) (options, error) {
 	var opts options
@@ -64,6 +74,8 @@ func parseArgs(args []string) (options, error) {
 			switch name {
 			case "help":
 				return opts, errHelp
+			case "version":
+				return opts, errVersion
 			case "context", "context-file", "prompt", "prompt-file", "engine", "include":
 				if !hasValue {
 					if i+1 >= len(args) {
@@ -180,4 +192,9 @@ func printUsage(out *os.File) {
 	fmt.Fprintln(out, "  --debug-prompt            Print the prompt before executing the engine")
 	fmt.Fprintln(out, "  --debug-command           Print the engine command before execution")
 	fmt.Fprintln(out, "  -h, --help                Show help")
+	fmt.Fprintln(out, "  --version                 Show version information")
+}
+
+func printVersion() {
+	fmt.Printf("git-ai-commit version %s (%s)\n", version, commit)
 }


### PR DESCRIPTION
This pull request adds explicit version reporting to the CLI and ensures version metadata is embedded at build time.

A new `--version` flag has been introduced to display the application version together with the corresponding Git commit hash. This allows users to quickly verify which build of `git-ai-commit` they are running, which is particularly useful when troubleshooting issues or comparing behavior across releases.

To support this, the build process has been updated to inject version and commit information at build time using Go linker flags. The GoReleaser configuration now passes the release version and short commit hash into the binary, replacing the previous hardcoded defaults used during local development.
