### PR TITLE
fix: unset CLAUDECODE for engine subprocesses

### DIFF
--- a/internal/engine/cli_test.go
+++ b/internal/engine/cli_test.go
@@ -23,3 +23,18 @@ func TestCLIGenerateUsesPromptArg(t *testing.T) {
 		t.Fatalf("output = %q", out)
 	}
 }
+
+func TestCLIGenerateUnsetsClaudeCodeEnv(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+	cli := CLI{
+		Command: "/bin/sh",
+		Args:    []string{"-c", "printf %s \"$CLAUDECODE\""},
+	}
+	out, err := cli.Generate("ignored")
+	if err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	if out != "" {
+		t.Fatalf("output = %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- remove CLAUDECODE from the engine subprocess environment
- prevent nested Claude Code session conflicts when running engine commands
- add a regression test to verify CLAUDECODE is unset in child processes

## Testing
- go test ./...

Closes #11