### PR TITLE
chore: disable attribution in default Claude engine settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Supported engines:
 - `gemini`
 - `codex`
 
+Built-in defaults are applied when `engines.<name>.args` is not set.
+For `claude`, defaults include:
+
+- `-p --model haiku`
+- `--settings "{\"attribution\":{\"commit\":\"\",\"pr\":\"\"}}"` (prevents automatic `Co-authored-by` metadata)
+
 If no engine is configured, auto-detection tries commands in this order: `claude` → `gemini` → `codex`. The first available command is used.
 
 Any other engine name is treated as a direct command and executed with the prompt on stdin.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -29,7 +29,7 @@ func TestSelectEngineClaudeDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectEngine error: %v", err)
 	}
-	if command != "claude -p --model haiku" {
+	if command != "claude -p --model haiku --settings {\"attribution\":{\"commit\":\"\",\"pr\":\"\"}}" {
 		t.Fatalf("command = %q", command)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,7 +52,7 @@ const defaultPromptPreset = "default"
 // DefaultEngineArgs provides default CLI arguments for known engines.
 var DefaultEngineArgs = map[string][]string{
 	"codex":        {"exec", "--model", "gpt-5.1-codex-mini"},
-	"claude":       {"-p", "--model", "haiku"},
+	"claude":       {"-p", "--model", "haiku", "--settings", "{\"attribution\":{\"commit\":\"\",\"pr\":\"\"}}"},
 	"cursor-agent": {"-p"},
 	"gemini":       {"-m", "gemini-2.5-flash", "-p", "{{prompt}}"},
 }


### PR DESCRIPTION
## Summary
- add Claude default --settings attribution override to suppress commit/PR attribution metadata
- update engine selection test expectation for default Claude command
- document the default Claude attribution behavior in README

Closes #13