### PR TITLE
feat: add --edit flag to edit commit message

### DIFF
--- a/cmd/git-ai-commit/main.go
+++ b/cmd/git-ai-commit/main.go
@@ -22,6 +22,7 @@ type options struct {
 	engine       string
 	amend        bool
 	addAll       bool
+	edit         bool
 	includeFiles []string
 	excludeFiles []string
 	debugPrompt  bool
@@ -51,6 +52,7 @@ func main() {
 		opts.engine,
 		opts.amend,
 		opts.addAll,
+		opts.edit,
 		opts.includeFiles,
 		opts.excludeFiles,
 		opts.debugPrompt,
@@ -91,6 +93,8 @@ func parseArgs(args []string) (options, error) {
 				}
 			case "amend":
 				opts.amend = true
+			case "edit":
+				opts.edit = true
 			case "all":
 				opts.addAll = true
 			case "debug-prompt":
@@ -194,6 +198,8 @@ func parseShortOptions(opts *options, arg string, args []string, index *int) err
 				return fmt.Errorf("missing value for -x")
 			}
 			opts.excludeFiles = append(opts.excludeFiles, value)
+		case 'e':
+			opts.edit = true
 		case 'h':
 			return errHelp
 		default:
@@ -214,6 +220,7 @@ func printUsage(out *os.File) {
 	fmt.Fprintln(out, "  --prompt-file VALUE       Path to a custom prompt file")
 	fmt.Fprintln(out, "  --engine VALUE            LLM engine name override")
 	fmt.Fprintln(out, "  --amend                   Amend the previous commit")
+	fmt.Fprintln(out, "  -e, --edit                Open the generated commit message in an editor before committing")
 	fmt.Fprintln(out, "  -a, --all                 Stage modified and deleted files before generating the message")
 	fmt.Fprintln(out, "  -i, --include VALUE       Stage specific files before generating the message")
 	fmt.Fprintln(out, "  -x, --exclude VALUE       Hide specific files from the diff for message generation")

--- a/cmd/git-ai-commit/main_test.go
+++ b/cmd/git-ai-commit/main_test.go
@@ -73,3 +73,36 @@ func TestParseArgs_ExcludeShortCluster(t *testing.T) {
 		t.Errorf("expected excludeFiles=[go.sum], got %v", opts.excludeFiles)
 	}
 }
+
+func TestParseArgs_EditLong(t *testing.T) {
+	opts, err := parseArgs([]string{"--edit"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.edit {
+		t.Error("expected edit to be true")
+	}
+}
+
+func TestParseArgs_EditShort(t *testing.T) {
+	opts, err := parseArgs([]string{"-e"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.edit {
+		t.Error("expected edit to be true")
+	}
+}
+
+func TestParseArgs_EditShortCluster(t *testing.T) {
+	opts, err := parseArgs([]string{"-ae"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.addAll {
+		t.Error("expected addAll to be true")
+	}
+	if !opts.edit {
+		t.Error("expected edit to be true")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,7 +11,7 @@ import (
 	"git-ai-commit/internal/prompt"
 )
 
-func Run(context, contextFile, promptName, promptFile, engineName string, amend, addAll bool, includeFiles, excludeFiles []string, debugPrompt, debugCommand bool) (err error) {
+func Run(context, contextFile, promptName, promptFile, engineName string, amend, addAll, edit bool, includeFiles, excludeFiles []string, debugPrompt, debugCommand bool) (err error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func Run(context, contextFile, promptName, promptFile, engineName string, amend,
 		return fmt.Errorf("empty commit message from engine")
 	}
 
-	if err := git.CommitWithMessage(message, amend); err != nil {
+	if err := git.CommitWithMessage(message, amend, edit); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This allows users to post-process the generated commit message before committing.