### PR TITLE
feat(cli): add --diff flag to show staged changes in editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Common options:
 - `--prompt-file VALUE` Path to a custom prompt file
 - `--engine VALUE` Override engine name
 - `--amend` Amend the previous commit
+- `-d`, `--diff` Show staged diff in the editor (implies `--edit`)
 - `-e`, `--edit` Open the generated commit message in an editor before committing
 - `-a`, `--all` Stage modified and deleted files before generating the message
 - `-i`, `--include VALUE` Stage specific files before generating the message

--- a/cmd/git-ai-commit/main.go
+++ b/cmd/git-ai-commit/main.go
@@ -23,6 +23,7 @@ type options struct {
 	amend        bool
 	addAll       bool
 	edit         bool
+	diff         bool
 	includeFiles []string
 	excludeFiles []string
 	debugPrompt  bool
@@ -53,6 +54,7 @@ func main() {
 		opts.amend,
 		opts.addAll,
 		opts.edit,
+		opts.diff,
 		opts.includeFiles,
 		opts.excludeFiles,
 		opts.debugPrompt,
@@ -93,6 +95,8 @@ func parseArgs(args []string) (options, error) {
 				}
 			case "amend":
 				opts.amend = true
+			case "diff":
+				opts.diff = true
 			case "edit":
 				opts.edit = true
 			case "all":
@@ -198,6 +202,8 @@ func parseShortOptions(opts *options, arg string, args []string, index *int) err
 				return fmt.Errorf("missing value for -x")
 			}
 			opts.excludeFiles = append(opts.excludeFiles, value)
+		case 'd':
+			opts.diff = true
 		case 'e':
 			opts.edit = true
 		case 'h':
@@ -220,6 +226,7 @@ func printUsage(out *os.File) {
 	fmt.Fprintln(out, "  --prompt-file VALUE       Path to a custom prompt file")
 	fmt.Fprintln(out, "  --engine VALUE            LLM engine name override")
 	fmt.Fprintln(out, "  --amend                   Amend the previous commit")
+	fmt.Fprintln(out, "  -d, --diff                Show staged diff in the editor (implies --edit)")
 	fmt.Fprintln(out, "  -e, --edit                Open the generated commit message in an editor before committing")
 	fmt.Fprintln(out, "  -a, --all                 Stage modified and deleted files before generating the message")
 	fmt.Fprintln(out, "  -i, --include VALUE       Stage specific files before generating the message")

--- a/cmd/git-ai-commit/main_test.go
+++ b/cmd/git-ai-commit/main_test.go
@@ -74,6 +74,39 @@ func TestParseArgs_ExcludeShortCluster(t *testing.T) {
 	}
 }
 
+func TestParseArgs_DiffLong(t *testing.T) {
+	opts, err := parseArgs([]string{"--diff"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.diff {
+		t.Error("expected diff to be true")
+	}
+}
+
+func TestParseArgs_DiffShort(t *testing.T) {
+	opts, err := parseArgs([]string{"-d"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.diff {
+		t.Error("expected diff to be true")
+	}
+}
+
+func TestParseArgs_DiffShortCluster(t *testing.T) {
+	opts, err := parseArgs([]string{"-de"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.diff {
+		t.Error("expected diff to be true")
+	}
+	if !opts.edit {
+		t.Error("expected edit to be true")
+	}
+}
+
 func TestParseArgs_EditLong(t *testing.T) {
 	opts, err := parseArgs([]string{"--edit"})
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,7 +12,7 @@ import (
 	"git-ai-commit/internal/prompt"
 )
 
-func Run(context, contextFile, promptName, promptFile, engineName string, amend, addAll, edit bool, includeFiles, excludeFiles []string, debugPrompt, debugCommand bool) (err error) {
+func Run(context, contextFile, promptName, promptFile, engineName string, amend, addAll, edit, showDiff bool, includeFiles, excludeFiles []string, debugPrompt, debugCommand bool) (err error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -88,7 +88,10 @@ func Run(context, contextFile, promptName, promptFile, engineName string, amend,
 		return fmt.Errorf("empty commit message from engine")
 	}
 
-	if err := git.CommitWithMessage(message, amend, edit); err != nil {
+	if showDiff {
+		edit = true
+	}
+	if err := git.CommitWithMessage(message, amend, edit, showDiff); err != nil {
 		return err
 	}
 	return nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -95,9 +95,9 @@ func HasHeadCommit() (bool, error) {
 	return true, nil
 }
 
-func CommitWithMessage(message string, amend, edit bool) error {
+func CommitWithMessage(message string, amend, edit, diff bool) error {
 	if edit {
-		return commitWithEdit(message, amend)
+		return commitWithEdit(message, amend, diff)
 	}
 	args := []string{"commit", "-F", "-"}
 	if amend {
@@ -113,7 +113,7 @@ func CommitWithMessage(message string, amend, edit bool) error {
 	return nil
 }
 
-func commitWithEdit(message string, amend bool) error {
+func commitWithEdit(message string, amend, diff bool) error {
 	f, err := os.CreateTemp("", "git-ai-commit-*.txt")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %v", err)
@@ -131,6 +131,9 @@ func commitWithEdit(message string, amend bool) error {
 	args := []string{"commit", "--edit", "-F", f.Name()}
 	if amend {
 		args = append(args, "--amend")
+	}
+	if diff {
+		args = append(args, "--verbose")
 	}
 	cmd := exec.Command("git", args...)
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
## Summary
- Add `-d` / `--diff` CLI flag that passes `--verbose` to `git commit` when in edit mode, showing the staged diff in the editor so the user can verify the AI-generated message against actual code changes
- `--diff` implies `--edit` — using it alone automatically opens the editor
- Maps to git's native `--verbose` flag for seamless integration

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (3 new test cases for `--diff`, `-d`, `-de` cluster)
- [ ] Manual: `git ai-commit --diff` opens editor with diff visible below commit message
- [ ] Manual: `git ai-commit -de` opens editor with diff (cluster shorthand)