### PR TITLE
refactor(internal/app): strip ANSI escape sequences from commit messages

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"git-ai-commit/internal/config"
@@ -124,8 +125,11 @@ func selectEngine(cfg config.Config) (engine.Engine, string, error) {
 	return engine.CLI{Command: name, Args: nil}, name, nil
 }
 
+var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
 func sanitizeMessage(message string) string {
-	clean := strings.TrimSpace(message)
+	clean := ansiEscapeRe.ReplaceAllString(message, "")
+	clean = strings.TrimSpace(clean)
 	if clean == "" {
 		return ""
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -188,6 +188,44 @@ func TestSelectEngineCustomArgs(t *testing.T) {
 	}
 }
 
+func TestSanitizeMessageStripANSIEscapeSequences(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "cursor back and erase",
+			input: "Add uni\x1b[3D\x1b[Kntended behavior fix",
+			want:  "Add unintended behavior fix",
+		},
+		{
+			name:  "multiple ANSI sequences",
+			input: "Fix \x1b[8D\x1b[K\x1b[4D\x1b[Kbug in parser",
+			want:  "Fix bug in parser",
+		},
+		{
+			name:  "SGR color codes",
+			input: "\x1b[32mAdd feature\x1b[0m",
+			want:  "Add feature",
+		},
+		{
+			name:  "no ANSI sequences",
+			input: "Clean commit message",
+			want:  "Clean commit message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeMessage(tt.input)
+			if got != tt.want {
+				t.Fatalf("sanitizeMessage(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSanitizeMessageCodeFence(t *testing.T) {
 	input := "```\nfeat: add thing\n```"
 	got := sanitizeMessage(input)


### PR DESCRIPTION
## Problem

Commit messages generated via `git ai-commit` have been getting polluted with ANSI escape sequences like `[8D[K`, `[4D[K`, etc. The root cause is `ollama run`'s word-wrap feature: even when stdout is a pipe (non-TTY), ollama emits cursor-back (`ESC[nD`) and erase-to-end-of-line (`ESC[K`) sequences to reflow words at the terminal width. Since `CLI.Generate()` pipes ollama's stdout straight into a `bytes.Buffer`, those control codes end up inside the final commit message.

## Solution

Defensive sanitization at the app layer. `sanitizeMessage()` now strips any ANSI CSI sequence matching `\x1b\[[0-9;]*[A-Za-z]` before the existing code-fence / backtick cleanup runs. Engine-agnostic — any future engine that leaks control codes will also produce clean messages.

The regex is intentionally scoped to CSI (`ESC [`) only. OSC, DECSC/DECRC, and single-shift families are left unhandled until observed in practice, to keep the scope narrow and justifiable.

## Changes

- `internal/app/app.go` — add package-level `ansiEscapeRe` and apply it at the top of `sanitizeMessage()`
- `internal/app/app_test.go` — add `TestSanitizeMessageStripANSIEscapeSequences` covering cursor-back + erase, multiple consecutive sequences, SGR color codes, ollama wordwrap-with-newline, and a no-op case

